### PR TITLE
Move help options to the personal_options hook

### DIFF
--- a/class-admin-help-admin.php
+++ b/class-admin-help-admin.php
@@ -89,7 +89,7 @@ class Admin_Help_Admin {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 
 		// user profile stuff, added by trishasalas & cleaned up by jazzs3quence
-		add_action( 'profile_personal_options', array( $this, 'admin_help_show_profile_fields' ) );
+		add_action( 'personal_options', array( $this, 'admin_help_show_profile_fields' ) );
 		add_action( 'personal_options_update', array( $this, 'admin_help_save_profile_fields' ) );
 		add_action( 'edit_user_profile_update', array( $this, 'admin_help_save_profile_fields' ) );
 
@@ -248,10 +248,9 @@ class Admin_Help_Admin {
 		$admin_help_overview = $user->has_prop( 'admin_help_overview' ) ? $user->get( 'admin_help_overview' ) : true;
 
 	?>
-		    <table class="form-table">
 		        <tr>
 					<th><label for="show_tooltips"><?php _e( 'Help Settings', 'admin-help' ); ?></label></th>
-					<td><?php // TODO turn this into checkboxes ?>
+					<td>
 						<label for="help_tooltips">
 							<input type="checkbox" id="help_tooltips" name="admin_help_tooltips" value="1" <?php checked( $admin_help_tooltips ); ?> />
 								<?php _e( 'Enable help tooltips.', 'admin-help' ); ?><br />
@@ -262,8 +261,6 @@ class Admin_Help_Admin {
 						</label>
 					</td>
 		        </tr>
-
-		    </table>
 	<?php }
 
 	/**


### PR DESCRIPTION
Using the profile_personal_options hook only shows the field if a user
is on their profile page, so admins couldn't see or modify a users help
settings. Admins should be able to modify all default settings.
