### PR TITLE
Help Overview - Responsive Styling

### DIFF
--- a/class-ah-o2-admin.php
+++ b/class-ah-o2-admin.php
@@ -209,7 +209,7 @@ class AH_O2_Admin {
 		$AH_O2_overview = $user->has_prop( 'AH_O2_overview' ) ? $user->get( 'AH_O2_overview' ) : true;
 
 	?>
-		        <tr>
+		        <tr id="Admin-Help">
 					<th><label for="show_tooltips"><?php _e( 'Help Settings', 'ah-o2' ); ?></label></th>
 					<td>
 						<label for="help_tooltips">

--- a/class-screen-admin.php
+++ b/class-screen-admin.php
@@ -746,6 +746,15 @@ class WP_Screen_Admin {
 						?>
 					</div>
 					
+					<div class="help-footer">
+						<div class="help-footer-menu">
+							<a href="#screen_meta_container" id="contextual-help-hide-link" class="icon-adminhelp show-settings" aria-controls="contextual-help-wrap" aria-expanded="false" ><div class="screen-meta-footer-icon dashicons dashicons-visibility"></div><?php _e( 'hide help' ); ?></a>
+						</div>
+						<div class="help-footer-menu">
+							<a href="<?php echo admin_url( "profile.php#Admin-Help" ); ?>" id="configure-help-link" class="icon-adminhelp" aria-expanded="false" ><div class="screen-meta-footer-icon dashicons dashicons-admin-generic"></div><?php _e( 'configure help' ); ?></a>
+						</div>
+					</div>
+					
 				</div>
 			</div>
 		<?php

--- a/css/admin.css
+++ b/css/admin.css
@@ -106,19 +106,6 @@
 	padding: 3px 0;
 }
 
-.contextual-help-tabs {
-    float: right;
-    margin: 0;
-    width: 25%;
-}
-
-.contextual-help-tabs-content {
-    float: left;
-    overflow: auto;
-    margin: 0 10px 0px 10px;
-    width: 70%;
-}
-
 #screen-options-wrap, #contextual-help-wrap {
     position: relative;
 	overflow-x: hidden;
@@ -137,3 +124,62 @@
 	font-size: 1.5em;
 	color: #0074A2;
 }
+
+@media screen and (max-width: 782px) {
+	.contextual-help-tabs {
+		margin: 0;
+		width: 100%;
+		float: none;
+		border-bottom: 1px solid #E1E1E1;
+	}
+
+	.contextual-help-tabs-content {
+		overflow: auto;
+		width: 100%;
+		margin: 0 10px 0px 10px;
+	}
+	
+	.help-footer-menu {
+		float: right;
+		margin: 0px 10px 0px 0px;
+	}
+
+}
+
+@media screen and (min-width: 783px) {
+	.contextual-help-tabs {
+		float: right;
+		margin: 0;
+		width: 25%;
+	}
+
+	.contextual-help-tabs-content {
+		float: left;
+		overflow: auto;
+		margin: 0 10px 0px 10px;
+		width: 70%;
+	}
+	
+	.help-footer {
+		clear: both;
+		width: 70%;
+		text-align: right;
+	}
+	
+
+	.help-footer-menu {
+		float: right;
+		margin: 0px 0px 0px 10px;
+	}
+	
+}
+
+.help-footer-menu a {
+	text-decoration: none;
+}
+
+.screen-meta-footer-icon {
+	padding: 2px 0;
+}
+
+


### PR DESCRIPTION
Responsive Styling to have Help Overview change to full width menu when Admin Menu Bar Changes.
Addition of Footer menu in overview of configure/hide 

**note that we might need to talk to Mel concerning new icons (styled i, hide "slashed eye")

I'll be doing another pass on styling, hopefully this weekend, as I haven't gotten the menu list styled per the mockup.
