### PR TITLE
Add tooltip delays

### DIFF
--- a/js/admin-help.js
+++ b/js/admin-help.js
@@ -31,6 +31,9 @@ function AdminHelp( helpitem ) {
 					.addClass( feedback.horizontal )
 					.appendTo( this );
 				}
+			},
+			show: {
+				delay: 500
 			}
 		});
 	};


### PR DESCRIPTION
Stops tooltips taking too much focus and makes for smoother fade animations. Fixes #49
